### PR TITLE
feature/library target names

### DIFF
--- a/nug4/G4Base/CMakeLists.txt
+++ b/nug4/G4Base/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 art_make_library( LIBRARIES PRIVATE
-                        nug4::MagneticFieldServices
+                        nug4::MagneticFieldService
                         nug4::MagneticField
                         nusimdata::SimulationBase
                         canvas::canvas

--- a/nug4/MagneticField/CMakeLists.txt
+++ b/nug4/MagneticField/CMakeLists.txt
@@ -4,7 +4,8 @@ cet_make_library(INTERFACE SOURCE MagneticField.h
   ROOT::Geom
   ROOT::Physics
 )
-cet_make_library(LIBRARY_NAME MagneticFieldStandard SOURCE MagneticFieldStandard.cxx
+cet_make_library(LIBRARY_NAME MagneticFieldStandard USE_PROJECT_NAME
+  SOURCE MagneticFieldStandard.cxx
   LIBRARIES
   PUBLIC
   nug4::MagneticField

--- a/nug4/MagneticFieldServices/CMakeLists.txt
+++ b/nug4/MagneticFieldServices/CMakeLists.txt
@@ -1,4 +1,5 @@
-cet_make_library(INTERFACE SOURCE MagneticFieldService.h
+cet_make_library(LIBRARY_NAME MagneticFieldService
+  INTERFACE SOURCE MagneticFieldService.h
   LIBRARIES INTERFACE
   art_plugin_types::serviceDeclaration
   nug4::MagneticField
@@ -7,7 +8,7 @@ cet_make_library(INTERFACE SOURCE MagneticFieldService.h
 cet_build_plugin(MagneticFieldServiceStandard art::service
   LIBRARIES PRIVATE
   nug4::MagneticFieldStandard
-  nug4::MagneticFieldServices
+  nug4::MagneticFieldService
   art::Framework_Services_Registry
   art::Framework_Principal
   fhiclcpp::fhiclcpp


### PR DESCRIPTION
- Ensure library on disk includes "nug4_" in filename:

  * `libMagneticFieldStandard.so` -> `libnug4_MagneticFieldStandard.so`

- Drop unwanted plural from `INTERFACE` target name:

  * `nug4::MagneticFieldServices` -> `nug4::MagneticFieldService`
